### PR TITLE
Added ability to set console suppress flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Or install it yourself as:
 
 SeedTray makes a couple assumptions about how you will organize your code.
 
-You need to create a object to represent your app with the same name as your 
+You need to create a object to represent your app with the same name as your
 Rails app. SeedTray will automatically use this object as the root of your view
 classes.
 
@@ -67,10 +67,11 @@ class @Fruit
 ```
 
 In application.js, require seed_tray *after* the rest of your JS is included.
-```
+``` javascript
 //= require jquery
 //= require jquery_ujs
 //= require turbolinks
+//= require_tree .
 ...
 //= require seed_tray
 ```
@@ -86,18 +87,29 @@ defined any methods or data on it:
 var app = new Fruit();
 ```
 
-Add the data attributes to the 
-```
+Add the data attributes to the
+``` html
 <body <%= page_data_attr %> >
+  ...
 </body>
 ```
 
 `page_data_attr` puts data attributes with the controller and action on your
 page. For example, if you were visiting /bananas/1, you'd get:
 
-```
+``` html
 <body data-controller='Bananas' data-action='Show' >
+  ...
 </body>
+```
+### Console Suppression
+
+By default, SeedTray will write to your browser's console when a script is executed or skipped.  Depending on your Javascript driver in your test suite, these messages may show in your testing console as well.
+
+To suppress these messages, simply add the following to the appropriate `config/environments/` file.
+ 
+``` ruby
+SeedTray.configure { |config| config.suppress_console = true }
 ```
 
 ## Namespaced Controllers
@@ -131,4 +143,3 @@ the [Contributor Covenant](http://contributor-covenant.org) code of conduct.
 ## License
 
 The gem is available as open source under the terms of the [MITLicense](http://opensource.org/licenses/MIT).
-

--- a/app/assets/javascripts/seed_tray.js.coffee.erb
+++ b/app/assets/javascripts/seed_tray.js.coffee.erb
@@ -20,19 +20,24 @@ class SeedTray
         @site_wide_render()
 
     delegate_render: =>
+        suppress_console = <%= SeedTray.configuration.suppress_console %>
         controller = $("[data-controller]").data("controller")
         action = $("[data-action]").data("action")
 
         if @root[controller] && @render_defined(@root[controller])
             @root[controller].render()
         else
-            console.info "Skipped #{@root.name}.#{controller}.render()."
+          unless suppress_console
+              console.info "Skipped #{@root.name}.#{controller}.render()."
 
         if @root[controller] && @root[controller][action] && @render_defined(@root[controller][action])
             @root[controller][action].render()
-            console.info "Executed #{@root.name}.#{controller}.#{action}.render()."
+            unless suppress_console
+              console.info "Executed #{@root.name}.#{controller}.#{action}.render()."
+
         else
-            console.info "Skipped #{@root.name}.#{controller}.#{action}.render()."
+            unless suppress_console
+              console.info "Skipped #{@root.name}.#{controller}.#{action}.render()."
 
     render_defined: (object) ->
         object.render != undefined

--- a/lib/seed_tray.rb
+++ b/lib/seed_tray.rb
@@ -2,4 +2,20 @@ require "seed_tray/version"
 
 module SeedTray
   require 'seed_tray/engine' if defined?(Rails)
+  class << self
+    attr_accessor :configuration
+  end
+
+  def self.configure
+    self.configuration ||= Configuration.new
+    yield(configuration)
+  end
+
+  class Configuration
+    attr_accessor :suppress_console
+  end
+
+  self.configure do |config|
+    config.suppress_console = false
+  end
 end


### PR DESCRIPTION
With these changes, you can set a flag in your desired environment to suppress the `console.info` messages called by seed_tray.  Console messages are _not_ suppressed by default

You can set the flag like so:  `SeedTray.configure { |config| config.suppress_console = true }`
